### PR TITLE
Add a `twp` function for prefixed tailwind

### DIFF
--- a/src/tw_cljs/core.cljs
+++ b/src/tw_cljs/core.cljs
@@ -16,10 +16,28 @@
    (tw [:a :b] {:on-click f}) => {:class [\"a\" \"b\"] :on-click f}
    (tw [:a] [\"b:c\"] [:d])   => {:class [\"a\" \"b:c\" \"d\"]}
    "
-  ([& xs]
-   (let [has-props? (map? (last xs))
-         props      (if has-props? (last xs) {})
-         classes    (->> (if has-props? (butlast xs) xs)
-                         (apply concat)
-                         (mapv tw->str))]
-     (merge-with merge {:class classes} props))))
+  [& xs]
+  (let [has-props? (map? (last xs))
+        props      (if has-props? (last xs) {})
+        classes    (->> (if has-props? (butlast xs) xs)
+                        (apply concat)
+                        (mapv tw->str))]
+    (merge-with merge {:class classes} props)))
+
+(defn- tw->prefixed-str [prefix x] (str prefix (tw->str x)))
+
+(defn twp
+  "Similar to `tw`, but accepts an initial prefix to apply such that tailwind styles
+   don't conflict with others.
+
+   Examples:
+   (twp \"tw-\" [:a :b] {:on-click f}) => {:class [\"tw-a\" \"tw-b\"] :on-click f}
+
+   See also https://tailwindcss.com/docs/configuration#prefix."
+  [prefix & xs]
+  (let [has-props? (map? (last xs))
+        props      (if has-props? (last xs) {})
+        classes    (->> (if has-props? (butlast xs) xs)
+                        (apply concat)
+                        (mapv (partial tw->prefixed-str prefix)))]
+    (merge-with merge {:class classes} props)))

--- a/test/tw_cljs/core_test.cljs
+++ b/test/tw_cljs/core_test.cljs
@@ -9,14 +9,14 @@
 
 (deftest single-with-props
   (let [f (fn [])]
-    (is {:on-click f :class ["font-bold"]}
-        (sut/tw [:font-bold] {:on-click f}))))
+    (is (= {:on-click f :class ["font-bold"]}
+           (sut/tw [:font-bold] {:on-click f})))))
 
 (deftest multi
-  (is {:class ["font-bold" "mt-4" "hover:font-normal"]}
-      (sut/tw [:font-bold] [:mt-4 "hover:font-normal"])))
+  (is (= {:class ["font-bold" "mt-4" "hover:font-normal"]}
+         (sut/tw [:font-bold] [:mt-4 "hover:font-normal"]))))
 
 (deftest multi-with-props
   (let [f (fn [])]
-    (is {:on-click f :class ["font-bold" "text-center"]}
-        (sut/tw [:font-bold] [:text-center] {:on-click f}))))
+    (is (= {:on-click f :class ["font-bold" "text-center"]}
+           (sut/tw [:font-bold] [:text-center] {:on-click f})))))

--- a/test/tw_cljs/core_test.cljs
+++ b/test/tw_cljs/core_test.cljs
@@ -20,3 +20,8 @@
   (let [f (fn [])]
     (is (= {:on-click f :class ["font-bold" "text-center"]}
            (sut/tw [:font-bold] [:text-center] {:on-click f})))))
+
+(deftest multi-with-props-and-prefix
+  (let [f (fn [])]
+    (is (= {:on-click f :class ["tw-font-bold" "tw-text-center"]}
+           (sut/twp "tw-" [:font-bold] [:text-center] {:on-click f})))))


### PR DESCRIPTION
When tailwind is used in eg. a bigger CMS context with a lot of other styles, you can configure it to add a prefix to all its own generated styles to avoid colliding with the base CMS styles. In this situation, `twp` will let you attach that prefix without having to change any underlying collections of tailwind directives.

Eg. if the tailwind prefix is `"tw-"`, then you can get back to something like normal use with

```clojure
(def tw (partial twp "tw-"))
```

See https://tailwindcss.com/docs/configuration#prefix.