### PR TITLE
Fix prefix behaviour with variant classes

### DIFF
--- a/src/tw_cljs/core.cljs
+++ b/src/tw_cljs/core.cljs
@@ -1,4 +1,6 @@
-(ns tw-cljs.core)
+(ns tw-cljs.core
+  (:require
+   [clojure.string :as string]))
 
 (defn- tw->str [x] (if (keyword? x) (name x) (str x)))
 
@@ -24,7 +26,18 @@
                         (mapv tw->str))]
     (merge-with merge {:class classes} props)))
 
-(defn- tw->prefixed-str [prefix x] (str prefix (tw->str x)))
+(defn- tw->prefixed-str
+  "Convert keyword or string to a properly-prefixed class string. Just tacks the
+   prefix on for non-variant classes. For variant classes, eg. hover:font-bold,
+   we have to nestle the prefix between the variant and the base class, eg.
+   hover:xx-font-bold if prefix is xx-."
+  [prefix x]
+  (let [s (tw->str x)
+        variant? #(string/includes? % ":")]
+    (if (variant? s)
+      (let [[variant base] (string/split s #":" 2)]
+        (str variant ":" prefix base))
+      (str prefix s))))
 
 (defn twp
   "Similar to `tw`, but accepts an initial prefix to apply such that tailwind styles

--- a/test/tw_cljs/core_test.cljs
+++ b/test/tw_cljs/core_test.cljs
@@ -25,3 +25,12 @@
   (let [f (fn [])]
     (is (= {:on-click f :class ["tw-font-bold" "tw-text-center"]}
            (sut/twp "tw-" [:font-bold] [:text-center] {:on-click f})))))
+
+(deftest tw->prefixed-str-test
+  (let [f #'sut/tw->prefixed-str] ;; suppress not-public warning
+    (is (= "tw-font-bold" (f "tw-" "font-bold")))
+    (is (= "hover:tw-font-bold" (f "tw-" "hover:font-bold")))))
+
+(deftest prefix-with-variants
+  (is (= {:class ["hover:tw-font-bold" "lg:tw-bg-red-500"]}
+         (sut/twp "tw-" ["hover:font-bold" "lg:bg-red-500"]))))


### PR DESCRIPTION
A variant class is one of the responsive or pseudo-class classes, eg.
`hover:opacity-50` or `sm:bg-blue-500`. The tailwind prefix system
actually applies the user-supplied prefix *after* the responsive prefix
when building the stylesheet.

This commit changes the prefix generation--assuming an example prefix of
`xx-`--from `xx-sm:bg-blue-500` (incorrect, therefore won't apply the
utility style) to `sm:xx-bg-blue-500` (correct).

See https://tailwindcss.com/docs/configuration#prefix.